### PR TITLE
fix iterator

### DIFF
--- a/check_netapp_ontap.pl
+++ b/check_netapp_ontap.pl
@@ -984,6 +984,7 @@ sub get_snap_space {
 	my $nahQuery = NaElement->new("query");
         my $nahVolInfo = NaElement->new("volume-attributes");
         my $nahVolIdInfo = NaElement->new("volume-id-attributes");
+        my $nahTag = NaElement->new("tag");
         my $strActiveTag = "";
         my %hshVolUsage;
 
@@ -996,12 +997,13 @@ sub get_snap_space {
         }
 
 		# The active tag is a feature of the NetApp API that allows you to do queries in batches. In this case we are getting records in batches of 100.
+        $nahVolIterator->child_add_string("max-records", 100);
+        $nahVolIterator->child_add($nahTag);
         while(defined($strActiveTag)) {
                 if ($strActiveTag ne "") {
-                        $nahVolIterator->child_add_string("tag", $strActiveTag);
+                    $nahTag->set_content($strActiveTag);
                 }
 
-                $nahVolIterator->child_add_string("max-records", 100);
 				# Invoke the request.
                 my $nahResponse = $nahStorage->invoke_elem($nahVolIterator);
                 validate_ontapi_response($nahResponse, "Failed volume query: ");
@@ -1053,6 +1055,7 @@ sub get_volume_space {
 	my $nahQuery = NaElement->new("query");
 	my $nahVolInfo = NaElement->new("volume-attributes");
 	my $nahVolIdInfo = NaElement->new("volume-id-attributes");
+    my $nahTag = NaElement->new("tag");
 	my $strActiveTag = "";
 	my %hshVolUsage;
 
@@ -1065,10 +1068,12 @@ sub get_volume_space {
 	}
 	
 	# The active tag is a feature of the NetApp API that allows you to do queries in batches. In this case we are getting records in batches of 100.
+    $nahVolIterator->child_add_string("max-records", 100);
+    $nahVolIterator->child_add($nahTag);
 	while(defined($strActiveTag)) {
-		if ($strActiveTag ne "") {
-                        $nahVolIterator->child_add_string("tag", $strActiveTag);
-                }
+        if ($strActiveTag ne "") {
+            $nahTag->set_content($strActiveTag);
+        }
 		
 		$nahVolIterator->child_add_string("max-records", 100);
 		# Invoke the request.


### PR DESCRIPTION
there is a bug in the current usage of volume-get-iter element. the code
nahVolIterator->child_add_string("tag", $strActiveTag)
adds a new child to the iterator instead of replacing the current child
as a result, next-tag never advances and loops forever

this can be tested by setting max-records to just 1 and seeing if while
loop terminates