### PR TITLE
fixing the case where the lif attr is not defined

### DIFF
--- a/check_netapp_ontap.pl
+++ b/check_netapp_ontap.pl
@@ -547,7 +547,11 @@ sub draw_html_table_interface_health {
 					}
 				}
 			} else {
-				$html_table .= "<td style=\"text-align: left; padding-left: 4px; padding-right: 6px;\">".$hrefInfo->{$lif}->{$attr}."</td>";
+                                if (defined $hrefInfo->{$lif}->{$attr}) {
+                                        $html_table .= "<td style=\"text-align: left; padding-left: 4px; padding-right: 6px;\">".$hrefInfo->{$lif}->{$attr}."</td>";
+                                } else {
+                                        $html_table .= "<td style=\"text-align: left; padding-left: 4px; padding-right: 6px;\"></td>";
+                                }
 			}
 		}
 		$html_table .= "</tr>";


### PR DESCRIPTION
fixing the case where the lif attr is not defined.
it happened on our env for the link-status attribute, during a takeover-giveback (while changing a DIMM)