### PR TITLE
Fix port_health output when report option is unset

### DIFF
--- a/check_netapp_ontap.pl
+++ b/check_netapp_ontap.pl
@@ -466,15 +466,17 @@ sub calc_interface_health {
 	}
 
 	if (!(defined($strOutput))) {
-		$strOutput = "OK - No problem found ($intObjectCount checked)|";
+		$strOutput = "OK - No problem found ($intObjectCount checked) ";
 	} else {
-		if ($strReport eq "short" || $strReport eq "long") {
-			$strOutput .= "|\n$strMultiline";
-		} elsif ($strReport eq "html") {
-			my $strHTML = draw_html_table_interface_health($hrefInterfaceInfo, $strCheckLIFStatus, $strCheckLIFHomeNode, $strCheckLIFHomePort);
-			$strOutput .= "|\n$strHTML";
+		if(defined($strReport)) {
+			if ($strReport eq "short" || $strReport eq "long") {
+				$strOutput .= "\n$strMultiline";
+			} elsif ($strReport eq "html") {
+				my $strHTML = draw_html_table_interface_health($hrefInterfaceInfo, $strCheckLIFStatus, $strCheckLIFHomeNode, $strCheckLIFHomePort);
+				$strOutput .= "\n$strHTML";
+			}
 		} else {
-			$strOutput .= "|\n"
+			$strOutput .= "\n"
 		}
 	}
 


### PR DESCRIPTION
port_health checking led to "Undefined variable" messages.
This PR adds a condition based on $strReport, so that the report option can be safely omitted.