### PR TITLE
removed experimental warnings from the smartmatch operator usage

### DIFF
--- a/check_netapp_ontap.pl
+++ b/check_netapp_ontap.pl
@@ -23,7 +23,7 @@ use NaServer;
 use NaElement;
 use Getopt::Long;
 use POSIX;
-use experimental;
+use experimental 'smartmatch';
 
 my $verbose = undef;
 my $debug = undef;

--- a/check_netapp_ontap.pl
+++ b/check_netapp_ontap.pl
@@ -23,6 +23,7 @@ use NaServer;
 use NaElement;
 use Getopt::Long;
 use POSIX;
+use experimental;
 
 my $verbose = undef;
 my $debug = undef;


### PR DESCRIPTION
removed experimental warnings from the smartmatch operator usage, the output will throw these errors:
```
    ./check_netapp_ontap.pl -H <netapp.host.com> -u nagios_user -p password -o snapshot_health -w  -c
    Smartmatch is experimental at ./check_netapp_ontap.pl line 425.
    Smartmatch is experimental at ./check_netapp_ontap.pl line 426.
    Smartmatch is experimental at ./check_netapp_ontap.pl line 427.
    ....results here
```

